### PR TITLE
Change response for /branch POST #54

### DIFF
--- a/src/routes/branch.js
+++ b/src/routes/branch.js
@@ -63,7 +63,7 @@ router.post('/', (request, response) => {
             return response.status(400).send('Bad query');
           } else {
             console.log('New branch added');
-            response.send(result);
+            response.json({id: result.insertId, name: name});
           }
         });
       }


### PR DESCRIPTION
Changed the response received when creating a new branch. Previously responded with the result-variable, now responds with the id and the name of the newly created branch. Example:

{
    "id": 2,
    "name": "New branch"
}

